### PR TITLE
Set white background 

### DIFF
--- a/damtrade/lib/pages/home.dart
+++ b/damtrade/lib/pages/home.dart
@@ -81,6 +81,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin{
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
         body: _pages[_selectedIndex], // Display content based on selected index
         bottomNavigationBar: NavigationBar(
         onDestinationSelected: (int index) {


### PR DESCRIPTION
When Data is not loading the application home screen shows as one progress bar and I also see this time a little bit of pink background show as, so now that time I am set to a white background it looks pretty.